### PR TITLE
Added grid undo and redo functionality

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -116,6 +116,14 @@
             <td><code>esc</code></td>
             <td>exit editor without saving</td>
         </tr>
+        <tr>
+            <td><code>ctrl + z</code></td>
+            <td>undo</td>
+        </tr>
+        <tr>
+            <td><code>ctrl + y</code></td>
+            <td>redo</td>
+        </tr>
         </tbody>
     </table>
 </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -117,11 +117,11 @@
             <td>exit editor without saving</td>
         </tr>
         <tr>
-            <td><code>ctrl + z</code></td>
+            <td><code>ctrl + z</code> or <code>⌘ + z</code></td>
             <td>undo</td>
         </tr>
         <tr>
-            <td><code>ctrl + y</code></td>
+            <td><code>ctrl + y</code> or <code>⌘ + y</code></td>
             <td>redo</td>
         </tr>
         </tbody>

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -116,6 +116,14 @@
             <td><code>esc</code></td>
             <td>exit editor without saving</td>
         </tr>
+        <tr>
+            <td><code>ctrl + z</code></td>
+            <td>undo</td>
+        </tr>
+        <tr>
+            <td><code>ctrl + y</code></td>
+            <td>redo</td>
+        </tr>
         </tbody>
     </table>
 </div>

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -117,11 +117,11 @@
             <td>exit editor without saving</td>
         </tr>
         <tr>
-            <td><code>ctrl + z</code></td>
+            <td><code>ctrl + z</code> or <code>⌘ + z</code></td>
             <td>undo</td>
         </tr>
         <tr>
-            <td><code>ctrl + y</code></td>
+            <td><code>ctrl + y</code> or <code>⌘ + y</code></td>
             <td>redo</td>
         </tr>
         </tbody>

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -720,7 +720,7 @@
                     break;
 
                 case 90: // undo
-                    if (e.ctrlKey) {
+                    if (e.ctrlKey || e.metaKey) {
                         var edit = plugin.undo();
 
                         if (('row' in edit) && ('column' in edit)) {
@@ -740,7 +740,7 @@
                     }
                     break;
                 case 89: // redo
-                    if (e.ctrlKey) {
+                    if (e.ctrlKey || e.metaKey) {
                         var edit = plugin.redo();
 
                         if (('row' in edit) && ('column' in edit)) {

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -7,9 +7,6 @@
     // current event model and forced focus causes grid to get scrolled in area
     // when editor moves/closes which is unnecessary
 
-
-    edits = [];
-
     $.fn.grid = function (data, columns, options) {
 
         var plugin = this,
@@ -161,6 +158,18 @@
             plugin.unbindEvents();
             plugin.$el.remove();
         };
+
+        plugin.addEdit = function (edit){
+            plugin.edits.push(edit);
+        };
+
+        plugin.removeLastEdit = function (){
+            plugin.edits.splice(-1,1);
+        };
+
+        plugin.getLastEdit = function () {
+            return plugin.edits[0];
+        }
 
         plugin.bindEvents = function () {
             // unbind previous events
@@ -560,10 +569,11 @@
             }
 
             // checks to see if any edits were made to the text
-            if(edits[0].value == plugin.getCellData(plugin.getActiveCell())) {
+            if(plugin.getLastEdit().value == plugin.getCellData(plugin.getActiveCell())) {
                 // removes the last element from the array if no changes were made
-                edits.splice(-1,1)
+                plugin.removeLastEdit();
             }
+            console.log(plugin.edits);
 
             // need to regain focus
             if (plugin.isEditing) {
@@ -611,8 +621,8 @@
                 "column": $td.index()
             };
 
-            // adds the edit to the end of the array
-            edits.push(edit);
+            // save the state prior to edit
+            plugin.addEdit(edit);
 
             // trigger editor:load event
             var data = {};
@@ -799,6 +809,7 @@
             plugin.columns = columns;
             plugin.$el = $(this);
             plugin.editors = {};
+            plugin.edits = [];
             return plugin;
         };
 

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -7,6 +7,9 @@
     // current event model and forced focus causes grid to get scrolled in area
     // when editor moves/closes which is unnecessary
 
+
+    edits = [];
+
     $.fn.grid = function (data, columns, options) {
 
         var plugin = this,
@@ -556,6 +559,12 @@
                 }
             }
 
+            // checks to see if any edits were made to the text
+            if(edits[0].value == plugin.getCellData(plugin.getActiveCell())) {
+                // removes the last element from the array if no changes were made
+                edits.splice(-1,1)
+            }
+
             // need to regain focus
             if (plugin.isEditing) {
                 $td.setActiveCell();
@@ -594,6 +603,16 @@
             var column = $td.data("column");
             var value = $td.text();
             plugin.activeEditor.setValue(value);
+
+            // stores the original content and records the cell row and column
+            var edit = {
+                "value": value,
+                "row": plugin.getRowData(plugin.getCellRow($td))["id"],
+                "column": $td.index()
+            };
+
+            // adds the edit to the end of the array
+            edits.push(edit);
 
             // trigger editor:load event
             var data = {};

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -188,6 +188,7 @@
         plugin.undo = function () {
             if (plugin.editPointer < 0) {
                 return [];
+                
             } else {
                 var edit = plugin.edits[plugin.editPointer];
                 plugin.editPointer -= 1;
@@ -738,7 +739,7 @@
                         }
                     }
                     break;
-                case 89: //redo
+                case 89: // redo
                     if (e.ctrlKey) {
                         var edit = plugin.redo();
 

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -708,12 +708,20 @@
                         var edit = plugin.getLastEdit();
 
                         if (('row' in edit) && ('column' in edit)) {
-                            var element = plugin.getRowCellsByIndex(edit.row - 1)[edit.column]
-                            
-                            element.innerHTML = '<div>' + edit.value + '</div>';
 
+                            var row = plugin.getRowByIndex(edit.row - 1);
+                            var element = plugin.getCellFromRowByIndex(row, edit.column);
+
+                            // set value from editor to the active cell
+                            element.html($("<div>").text(edit.value));
+ 
+                            // trigger editor:save event
+                            var data = {};
+                            data[element.data("column")] = edit.value;
+                            plugin.events.trigger("editor:save", data, element);
+
+                            // remove the last edit
                             plugin.removeLastEdit(edit);
-                            
                         }
                     }
             }

--- a/src/sensei-grid.js
+++ b/src/sensei-grid.js
@@ -168,7 +168,11 @@
         };
 
         plugin.getLastEdit = function () {
-            return plugin.edits[0];
+            if(plugin.edits[0]){
+                return plugin.edits[plugin.edits.length - 1];
+            } else {
+                return [];
+            }
         }
 
         plugin.bindEvents = function () {
@@ -573,7 +577,6 @@
                 // removes the last element from the array if no changes were made
                 plugin.removeLastEdit();
             }
-            console.log(plugin.edits);
 
             // need to regain focus
             if (plugin.isEditing) {
@@ -637,7 +640,7 @@
             var preventDefault = true;
 
             // all keyCodes that will be used
-            var codes = [8, 9, 13, 27, 37, 38, 39, 40];
+            var codes = [8, 9, 13, 27, 37, 38, 39, 40, 90];
 
             // specific keyCodes that won't be hijacked from the editor
             var editorCodes = [8, 37, 38, 39, 40];
@@ -699,6 +702,20 @@
                 case 8: // backspace
                     plugin.clearActiveCell();
                     break;
+
+                case 90: // undo
+                    if (e.ctrlKey) {
+                        var edit = plugin.getLastEdit();
+
+                        if (('row' in edit) && ('column' in edit)) {
+                            var element = plugin.getRowCellsByIndex(edit.row - 1)[edit.column]
+                            
+                            element.innerHTML = '<div>' + edit.value + '</div>';
+
+                            plugin.removeLastEdit(edit);
+                            
+                        }
+                    }
             }
 
             if (preventDefault) {


### PR DESCRIPTION
This pull request resolves #1 and implements undo and redo functionality used by the keyboard shortcuts:
 - <kbd>ctrl</kbd> + <kbd>z</kbd> (undo)
 - <kbd>ctrl</kbd> + <kbd>y</kbd> (redo)

In short, this is done by constructing an `edit` object every time the editor is exited:

    var edit = {
        "previousState": plugin.getCellData($td),
        "currentState": val,
        "row": plugin.getRowData(plugin.getCellRow($td))["id"],
        "column": $td.index()
    };

This object tracks the initial and final states of the cell, as well as the coordinates of the changed cell. These edits are pushed into an `edits` array. When the undo and redo shortcuts are pressed, an `editPointer` is shifted, returning the appropriate `edit`.

Please let me know your thoughts on this feature immplementation. It seems to be 100% stable and functional, even considering edge cases involving strange combinations of edits and undo / redo.

Thanks!